### PR TITLE
Move dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "url": "https://github.com/dracula/prism/issues"
   },
   "homepage": "https://github.com/dracula/prism#readme",
-  "dependencies": {
+  "devDependencies": {
+    "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.6",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.7.1",
@@ -39,9 +40,6 @@
     "react-dom": "^17.0.1",
     "react-scripts": "^4.0.2",
     "web-vitals": "^1.1.0"
-  },
-  "devDependencies": {
-    "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.6"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
The "main" file for this package is css, which has no dependencies. Fixes #16